### PR TITLE
Nightly builds

### DIFF
--- a/.github/workflows/release-nightly.yml
+++ b/.github/workflows/release-nightly.yml
@@ -127,7 +127,7 @@ jobs:
         if: runner.os == 'Windows'
         run: npm run build:app -- -- -- nsis --publish never --x64
 
-      - name: Upload binaries
+      - name: Tweak binaries before upload
         shell: bash
         run: |
           cd open-lens/dist
@@ -135,10 +135,14 @@ jobs:
           for i in $(find . -name '*.dmg' ! -name '*-arm64.dmg' ! -name '*-amd64.dmg'); do
             mv -f "$i" "${i%.dmg}-amd64.dmg"
           done
-          for i in *Setup*; do
+          for i in $(find . -name '*Setup*'); do
             mv -f "$i" "${i/ Setup /-}"
           done
-          gh release upload nightly-${{ needs.make-draft-release.outputs.date }} Freelens*.* --repo dex4er/freelens-nightly-builds
+
+      - name: Upload binaries
+        shell: bash
+        run: |
+          gh release upload nightly-${{ needs.make-draft-release.outputs.date }} open-lens/dist/Freelens*.* --repo dex4er/freelens-nightly-builds
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 

--- a/.github/workflows/release-nightly.yml
+++ b/.github/workflows/release-nightly.yml
@@ -125,19 +125,19 @@ jobs:
       - name: Build
         run: npm run build
         env:
-          DOWNLOAD_ALL_ARCHITECTURES: "true"
+          DOWNLOAD_ALL_ARCHITECTURES: "${{ runner.os != 'Windows' }}"
 
       - name: Build Electron app (macOS)
         if: ${{ runner.os == 'macOS' }}
-        run: npm run build:app -- -- -- --publish never --x64 --arm64
+        run: npm run build:app -- -- -- --publish never dmg --x64 --arm64
 
       - name: Build Electron app (Linux)
         if: ${{ runner.os == 'Linux' }}
-        run: npm run build:app -- -- -- --publish never --x64 --arm64
+        run: npm run build:app -- -- -- --publish never AppImage deb rpm --x64 --arm64
 
       - name: Build Electron app (Windows)
         if: ${{ runner.os == 'Windows' }}
-        run: npm run build:app -- -- -- --publish never --x64
+        run: npm run build:app -- -- -- --publish never nsis --x64
 
       - name: Upload binaries (macOS, Linux)
         if: ${{ runner.os != 'Windows' }}

--- a/.github/workflows/release-nightly.yml
+++ b/.github/workflows/release-nightly.yml
@@ -12,10 +12,10 @@ on:
   workflow_dispatch: {}
 
 permissions:
-  contents: read
+  contents: write
 
 jobs:
-  make-release:
+  make-draft-release:
     name: make release
 
     permissions: write-all
@@ -27,23 +27,20 @@ jobs:
         id: date
         run: echo "date=$(date +'%Y-%m-%d')" >> $GITHUB_ENV
 
-      - name: Delete existing nightly release
-        uses: liudonghua123/delete-release-action@v1
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      - name: Checkout
+        uses: actions/checkout@v4
         with:
-          release_name: nightly-${{ env.date }}
-          suppress_errors: true
+          repository: dex4er/freelens
 
-      - name: Create nightly release
-        uses: viperproject/create-nightly-release@v1
+      - name: Delete existing nightly release
+        run: gh release delete nightly-${{ env.date }} --yes --cleanup-tag || true
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        with:
-          tag_name: nightly-${{ env.date }}
-          release_name: Nightly Release ${{ env.date }}
-          keep_num: 0
-          keep_tags: false
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Create nightly release draft
+        run: gh release create nightly-${{ env.date }} --draft --title "Nightly Release ${{ env.date }}"
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
     outputs:
       date: ${{ env.date }}
@@ -51,10 +48,11 @@ jobs:
   build-app:
     name: build app
 
-    permissions: write-all
+    permissions:
+      contents: write
 
     needs:
-      - make-release
+      - make-draft-release
 
     strategy:
       fail-fast: false
@@ -118,7 +116,7 @@ jobs:
 
       - name: Upload binaries (Bash)
         if: ${{ runner.os != 'Windows' }}
-        run: cd open-lens/dist && gh release upload nightly-${{ needs.make-release.outputs.date }} $(yq -r '.files[].url' latest-*.yml)
+        run: cd open-lens/dist && gh release upload nightly-${{ needs.make-draft-release.outputs.date }} $(yq -r '.files[].url' latest-*.yml)
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
@@ -133,6 +131,27 @@ jobs:
             $yamlContent = Get-Content -Path $yamlFile.FullName | ConvertFrom-Yaml
             $yamlContent.files.url
           }
-          gh release upload nightly-${{ needs.make-release.outputs.date }} $files
+          gh release upload nightly-${{ needs.make-draft-release.outputs.date }} $files
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+  publish-release:
+    name: make release
+
+    needs:
+      - make-draft-release
+      - build-app
+
+    permissions:
+      contents: write
+
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Publish nightly release
+        run: gh release edit nightly-${{ needs.make-draft-release.outputs.date }} --draft=false
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/release-nightly.yml
+++ b/.github/workflows/release-nightly.yml
@@ -78,6 +78,10 @@ jobs:
           repository: dex4er/freelens
           ref: dex4er
 
+      - name: Save current revision
+        id: current_revision
+        run: echo "sha=$(git rev-parse HEAD)" >> "$GITHUB_OUTPUT"
+
       - name: Setup node
         uses: actions/setup-node@v4
         with:
@@ -103,9 +107,9 @@ jobs:
         if: runner.os == 'macOS'
         run: brew install python-setuptools
 
-      - name: Set version number and tweak build parameters
+      - name: Set version number
         shell: bash
-        run: cd open-lens && jq ".version += \"-nightly-${{ needs.make-draft-release.outputs.date }}\" | .build.npmRebuild = true" package.json > package.json.new && mv -f package.json.new package.json
+        run: cd open-lens && jq ".version += \"-nightly-${{ needs.make-draft-release.outputs.date }}\"" package.json > package.json.new && mv -f package.json.new package.json
 
       - name: Install required dependencies
         run: npm ci
@@ -130,6 +134,7 @@ jobs:
       - name: Tweak binaries before upload
         shell: bash
         run: |
+          find . -name '*pty.node' -print0 | xargs -0 file
           cd open-lens/dist
           rm -f *.blockmap
           find . -name '*.dmg' ! -name '*-arm64.dmg' ! -name '*-amd64.dmg' | while read -r f; do
@@ -145,6 +150,9 @@ jobs:
           gh release upload nightly-${{ needs.make-draft-release.outputs.date }} open-lens/dist/Freelens*.* --repo dex4er/freelens-nightly-builds
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+    outputs:
+      sha: ${{ steps.current_revision.outputs.sha }}
 
   publish-release:
     name: publish release
@@ -164,6 +172,6 @@ jobs:
 
       - name: Publish nightly release
         if: github.ref_name == 'dex4er'
-        run: gh release edit nightly-${{ needs.make-draft-release.outputs.date }} --draft=false
+        run: gh release edit nightly-${{ needs.make-draft-release.outputs.date }} --draft=false --notes="Based on https://github.com/dex4er/freelens/tree/${{ needs.build-app.outputs.sha }}}"
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/release-nightly.yml
+++ b/.github/workflows/release-nightly.yml
@@ -83,14 +83,9 @@ jobs:
         with:
           node-version-file: .nvmrc
 
-      - name: Get npm cache directory (macOS, Linux)
-        if: runner.os != 'Windows'
+      - name: Get npm cache directory
+        shell: bash
         run: echo "npm_cache_dir=$(npm config get cache)" >> ${GITHUB_ENV}
-
-      - name: Get npm cache directory (Windows)
-        if: runner.os == 'Windows'
-        shell: pwsh
-        run: echo "npm_cache_dir=$(npm config get cache)" >> ${env:GITHUB_ENV}
 
       - uses: actions/cache@v4
         id: npm-cache
@@ -100,29 +95,17 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-node-
 
-      - name: Install cross-compiler (Linux)
+      - name: Install dependencies (Linux)
         if: runner.os == 'Linux'
         run: sudo apt-get install -y --no-install-recommends gcc-aarch64-linux-gnu g++-aarch64-linux-gnu
 
-      - name: Install Python setuptools (macOS)
+      - name: Install dependencies (macOS)
         if: runner.os == 'macOS'
         run: brew install python-setuptools
 
-      - name: Set version number and NPM rebuild (macOS, Linux)
-        if: runner.os != 'Windows'
-        run: yq -i -pj -oj ".version += \"-nightly-${{ needs.make-draft-release.outputs.date }}\" | .build.npmRebuild = true" package.json
-
-      - name: Set version number and NPM rebuild (Windows)
-        if: runner.os == 'Windows'
-        shell: pwsh
-        run: |
-          $packageJsonPath = "open-lens\package.json"
-          $packageJsonContent = Get-Content -Path $packageJsonPath -Raw
-          $packageJson = $packageJsonContent | ConvertFrom-Json
-          $packageJson.version = $packageJson.version + "-nightly-${{ needs.make-draft-release.outputs.date }}"
-          $packageJson.build.npmRebuild = True
-          $updatedPackageJsonContent = $packageJson | ConvertTo-Json -Depth 100
-          $updatedPackageJsonContent | Set-Content -Path $packageJsonPath -Force
+      - name: Set version number and tweak build parameters
+        shell: bash
+        run: jq ".version += \"-nightly-${{ needs.make-draft-release.outputs.date }}\" | .build.npmRebuild = true" package.json > package.json.new && mv -f package.json.new package.json
 
       - name: Install required dependencies
         run: npm ci
@@ -130,7 +113,7 @@ jobs:
       - name: Build
         run: npm run build
         env:
-          DOWNLOAD_ALL_ARCHITECTURES: "runner.os != 'Windows'"
+          DOWNLOAD_ALL_ARCHITECTURES: "${{ runner.os != 'Windows' }}"
 
       - name: Build Electron app (macOS)
         if: runner.os == 'macOS'
@@ -144,24 +127,17 @@ jobs:
         if: runner.os == 'Windows'
         run: npm run build:app -- -- -- nsis --publish never --x64
 
-      - name: Upload binaries (macOS, Linux)
-        if: runner.os != 'Windows' && github.ref_name == 'dex4er'
+      - name: Upload binaries
+        shell: bash
         run: |
           cd open-lens/dist
           rm -f *.blockmap
-          for i in $(find . -name '*.dmg' ! -name '*-arm64.dmg'); do
-            mv $i ${i%.dmg}-amd64.dmg
+          for i in $(find . -name '*.dmg' ! -name '*-arm64.dmg' ! -name '*-amd64.dmg'); do
+            mv -f "$i" "${i%.dmg}-amd64.dmg"
           done
-          gh release upload nightly-${{ needs.make-draft-release.outputs.date }} Freelens*.* --repo dex4er/freelens-nightly-builds
-        env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-
-      - name: Upload binaries (Windows)
-        if: runner.os == 'Windows' && github.ref_name == 'dex4er'
-        shell: pwsh
-        run: |
-          Set-Location -Path "open-lens/dist"
-          Remove-Item -Path *.blockmap -Force
+          for i in *Setup*; do
+            mv -f "$i" "${i/ Setup /-}"
+          done
           gh release upload nightly-${{ needs.make-draft-release.outputs.date }} Freelens*.* --repo dex4er/freelens-nightly-builds
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/release-nightly.yml
+++ b/.github/workflows/release-nightly.yml
@@ -18,6 +18,8 @@ jobs:
   make-release:
     name: make release
 
+    permissions: write-all
+
     runs-on: ubuntu-latest
 
     steps:
@@ -40,6 +42,8 @@ jobs:
 
   build-app:
     name: build app
+
+    permissions: write-all
 
     needs:
       - make-release

--- a/.github/workflows/release-nightly.yml
+++ b/.github/workflows/release-nightly.yml
@@ -108,7 +108,23 @@ jobs:
       - name: Build Electron app
         run: npm run build:app
 
-      - name: Upload binaries
+      - name: Upload binaries (Bash)
+        if: ${{ runner.os != 'Windows' }}
         run: cd open-lens/dist && gh release upload nightly-${{ needs.make-release.outputs.date }} $(yq -r '.files[].url' latest-*.yml)
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Upload binaries (Pwsh)
+        if: ${{ runner.os == 'Windows' }}
+        shell: pwsh
+        run: |
+          Install-Module -Name powershell-yaml -RequiredVersion 0.4.2
+          Set-Location -Path "open-lens/dist"
+          $yamlFiles = Get-ChildItem -Filter 'latest-*.yml'
+          $files = foreach ($yamlFile in $yamlFiles) {
+            $yamlContent = Get-Content -Path $yamlFile.FullName | ConvertFrom-Yaml
+            $yamlContent.files.url
+          }
+          gh release upload nightly-${{ needs.make-release.outputs.date }} $files
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/release-nightly.yml
+++ b/.github/workflows/release-nightly.yml
@@ -29,8 +29,6 @@ jobs:
 
       - name: Checkout
         uses: actions/checkout@v4
-        with:
-          repository: dex4er/freelens
 
       - name: Delete existing nightly release
         run: gh release delete nightly-${{ env.date }} --yes --cleanup-tag || true
@@ -116,7 +114,7 @@ jobs:
 
       - name: Upload binaries (Bash)
         if: ${{ runner.os != 'Windows' }}
-        run: cd open-lens/dist && gh release upload nightly-${{ needs.make-draft-release.outputs.date }} $(yq -r '.files[].url' latest-*.yml)
+        run: cd open-lens/dist && gh release upload nightly-${{ needs.make-draft-release.outputs.date }} $(yq -r '.files[].url' latest-*.yml) --repo dex4er/freelens-nightly-builds
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
@@ -131,7 +129,7 @@ jobs:
             $yamlContent = Get-Content -Path $yamlFile.FullName | ConvertFrom-Yaml
             $yamlContent.files.url
           }
-          gh release upload nightly-${{ needs.make-draft-release.outputs.date }} $files
+          gh release upload nightly-${{ needs.make-draft-release.outputs.date }} $files --repo dex4er/freelens-nightly-builds
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 

--- a/.github/workflows/release-nightly.yml
+++ b/.github/workflows/release-nightly.yml
@@ -16,7 +16,7 @@ permissions:
 
 jobs:
   make-draft-release:
-    name: make release
+    name: make draft release
 
     permissions: write-all
 
@@ -136,7 +136,7 @@ jobs:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
   publish-release:
-    name: make release
+    name: publish release
 
     needs:
       - make-draft-release

--- a/.github/workflows/release-nightly.yml
+++ b/.github/workflows/release-nightly.yml
@@ -4,9 +4,6 @@ on:
   push:
     branches:
       - "**"
-  pull_request:
-    branches:
-      - main
   schedule:
     - cron: "0 2 * * *"
   workflow_dispatch: {}

--- a/.github/workflows/release-nightly.yml
+++ b/.github/workflows/release-nightly.yml
@@ -100,7 +100,7 @@ jobs:
 
       - name: Install cross-compiler (Linux)
         if: ${{ runner.os == 'Linux' }}
-        run: apt-get install -y --no-install-recommends gcc-aarch64-linux-gnu g++-aarch64-linux-gnu
+        run: sudo apt-get install -y --no-install-recommends gcc-aarch64-linux-gnu g++-aarch64-linux-gnu
 
       - name: Install Python setuptools (macOS)
         if: ${{ runner.os == 'macOS' }}
@@ -124,24 +124,22 @@ jobs:
       - name: Install required dependencies
         run: npm ci
 
+      - name: Build
+        run: npm run build
+        env:
+          DOWNLOAD_ALL_ARCHITECTURES: "true"
+
       - name: Build Electron app (macOS)
         if: ${{ runner.os == 'macOS' }}
         run: npm run build:app -- -- -- --x64 --arm64
-        env:
-          DOWNLOAD_ALL_ARCHITECTURES: "true"
 
       - name: Build Electron app (Linux)
         if: ${{ runner.os == 'Linux' }}
         run: npm run build:app -- -- -- --x64 --arm64
-        env:
-          BUILD_NUMBER: nightly-${{ needs.make-draft-release.outputs.date }}
-          DOWNLOAD_ALL_ARCHITECTURES: "true"
 
       - name: Build Electron app (Windows)
         if: ${{ runner.os == 'Windows' }}
         run: npm run build:app -- -- -- --x64
-        env:
-          BUILD_NUMBER: nightly-${{ needs.make-draft-release.outputs.date }}
 
       - name: Upload binaries (macOS, Linux)
         if: ${{ runner.os != 'Windows' }}

--- a/.github/workflows/release-nightly.yml
+++ b/.github/workflows/release-nightly.yml
@@ -27,6 +27,11 @@ jobs:
         id: date
         run: echo "date=$(date +'%Y-%m-%d')" >> $GITHUB_ENV
 
+      - name: Delete existing nightly release
+        run: gh release delete nightly-${{ env.date }} -y || true
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
       - name: Create nightly release
         uses: viperproject/create-nightly-release@v1
         env:

--- a/.github/workflows/release-nightly.yml
+++ b/.github/workflows/release-nightly.yml
@@ -69,7 +69,7 @@ jobs:
           - os: macos-latest
             arch: arm64
           - os: macos-latest
-            arch: x86
+            arch: x64
           - os: windows-latest
             arch: x64
 

--- a/.github/workflows/release-nightly.yml
+++ b/.github/workflows/release-nightly.yml
@@ -35,13 +35,13 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Delete existing nightly release
-        if: github.ref_name == 'dex4er'
+        if: github.ref_name == 'main'
         run: gh release delete nightly-${{ env.date }} --yes --cleanup-tag || true
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Create nightly release draft
-        if: github.ref_name == 'dex4er'
+        if: github.ref_name == 'main'
         run: gh release create nightly-${{ env.date }} --draft --title "Nightly Release ${{ env.date }}"
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -79,8 +79,8 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
         with:
-          repository: dex4er/freelens
-          ref: dex4er
+          repository: freelensapp/freelens
+          ref: main
 
       - name: Save current revision
         id: current_revision
@@ -166,7 +166,7 @@ jobs:
       - name: Upload binaries
         shell: bash
         run: |
-          gh release upload nightly-${{ needs.make-draft-release.outputs.date }} open-lens/dist/Freelens*.* --repo dex4er/freelens-nightly-builds
+          gh release upload nightly-${{ needs.make-draft-release.outputs.date }} open-lens/dist/Freelens*.* --repo freelensapp/freelens-nightly-builds
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
@@ -192,8 +192,8 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Add notes to nightly release
-        if: github.ref_name == 'dex4er'
-        run: gh release edit nightly-${{ needs.make-draft-release.outputs.date }} --notes="Based on https://github.com/dex4er/freelens/tree/${{ needs.build-app.outputs.sha }}"
+        if: github.ref_name == 'main'
+        run: gh release edit nightly-${{ needs.make-draft-release.outputs.date }} --notes="Based on https://github.com/freelensapp/freelens/tree/${{ needs.build-app.outputs.sha }}"
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
@@ -215,7 +215,7 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Publish nightly release
-        if: github.ref_name == 'dex4er'
+        if: github.ref_name == 'main'
         run: gh release edit nightly-${{ needs.make-draft-release.outputs.date }} --draft=false
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/release-nightly.yml
+++ b/.github/workflows/release-nightly.yml
@@ -74,17 +74,18 @@ jobs:
         uses: actions/checkout@v4
         with:
           repository: dex4er/freelens
+          ref: dex4er
 
       - name: Setup node
         uses: actions/setup-node@v4
         with:
           node-version-file: .nvmrc
 
-      - name: Get npm cache directory (Bash)
+      - name: Get npm cache directory (macOS, Linux)
         if: ${{ runner.os != 'Windows' }}
         run: echo "npm_cache_dir=$(npm config get cache)" >> ${GITHUB_ENV}
 
-      - name: Get npm cache directory (Pwsh)
+      - name: Get npm cache directory (Windows)
         if: ${{ runner.os == 'Windows' }}
         shell: pwsh
         run: echo "npm_cache_dir=$(npm config get cache)" >> ${env:GITHUB_ENV}
@@ -97,32 +98,62 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-node-
 
+      - name: Install cross-compiler (Linux)
+        if: ${{ runner.os == 'Linux' }}
+        run: apt-get install -y --no-install-recommends gcc-aarch64-linux-gnu g++-aarch64-linux-gnu
+
       - name: Install Python setuptools (macOS)
         if: ${{ runner.os == 'macOS' }}
         run: brew install python-setuptools
 
+      - name: Set version number
+        if: ${{ runner.os != 'Windows' }}
+        run: yq -i -pj -oj ".version += \"-nightly-${{ needs.make-draft-release.outputs.date }}\"" package.json
+
+      - name: Set version number (Windows)
+        if: ${{ runner.os == 'Windows' }}
+        shell: pwsh
+        run: |
+          $packageJsonPath = "open-lens\package.json"
+          $packageJsonContent = Get-Content -Path $packageJsonPath -Raw
+          $packageJson = $packageJsonContent | ConvertFrom-Json
+          $packageJson.version = $packageJson.version + "-nightly-${{ needs.make-draft-release.outputs.date }}"
+          $updatedPackageJsonContent = $packageJson | ConvertTo-Json -Depth 100
+          $updatedPackageJsonContent | Set-Content -Path $packageJsonPath -Force
+
       - name: Install required dependencies
         run: npm ci
 
-      - name: Build
-        run: npm run build
+      - name: Build Electron app (macOS)
+        if: ${{ runner.os == 'macOS' }}
+        run: npm run build:app -- -- -- --x64 --arm64
+        env:
+          DOWNLOAD_ALL_ARCHITECTURES: "true"
 
-      - name: Build Electron app
-        run: npm run build:app
+      - name: Build Electron app (Linux)
+        if: ${{ runner.os == 'Linux' }}
+        run: npm run build:app -- -- -- --x64 --arm64
+        env:
+          BUILD_NUMBER: nightly-${{ needs.make-draft-release.outputs.date }}
+          DOWNLOAD_ALL_ARCHITECTURES: "true"
+
+      - name: Build Electron app (Windows)
+        if: ${{ runner.os == 'Windows' }}
+        run: npm run build:app -- -- -- --x64
         env:
           BUILD_NUMBER: nightly-${{ needs.make-draft-release.outputs.date }}
 
-      - name: Upload binaries (Bash)
+      - name: Upload binaries (macOS, Linux)
         if: ${{ runner.os != 'Windows' }}
         run: cd open-lens/dist && gh release upload nightly-${{ needs.make-draft-release.outputs.date }} $(yq -r '.files[].url' latest-*.yml) --repo dex4er/freelens-nightly-builds
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Upload binaries (Pwsh)
+      - name: Upload binaries (Windows)
         if: ${{ runner.os == 'Windows' }}
         shell: pwsh
         run: |
-          Install-Module -Name powershell-yaml -RequiredVersion 0.4.2
+          Install-Module -Name powershell-yaml -RequiredVersion 0.4.2 -Force
           Set-Location -Path "open-lens/dist"
           $yamlFiles = Get-ChildItem -Filter 'latest-*.yml'
           $files = foreach ($yamlFile in $yamlFiles) {

--- a/.github/workflows/release-nightly.yml
+++ b/.github/workflows/release-nightly.yml
@@ -41,7 +41,7 @@ jobs:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Create nightly release draft
-        if: github.ref_name == 'dexter'
+        if: github.ref_name == 'dex4er'
         run: gh release create nightly-${{ env.date }} --draft --title "Nightly Release ${{ env.date }}"
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/release-nightly.yml
+++ b/.github/workflows/release-nightly.yml
@@ -132,11 +132,11 @@ jobs:
         run: |
           cd open-lens/dist
           rm -f *.blockmap
-          for i in $(find . -name '*.dmg' ! -name '*-arm64.dmg' ! -name '*-amd64.dmg'); do
-            mv -f "$i" "${i%.dmg}-amd64.dmg"
+          find . -name '*.dmg' ! -name '*-arm64.dmg' ! -name '*-amd64.dmg' | while read -r f; do
+            mv -f "$f" "${f%.dmg}-amd64.dmg"
           done
-          for i in $(find . -name '*Setup*'); do
-            mv -f "$i" "${i/ Setup /-}"
+          find . -name '*Setup*' | while read -r f; do
+            mv -f "$f" "${f/ Setup /-}"
           done
 
       - name: Upload binaries

--- a/.github/workflows/release-nightly.yml
+++ b/.github/workflows/release-nightly.yml
@@ -129,15 +129,15 @@ jobs:
 
       - name: Build Electron app (macOS)
         if: ${{ runner.os == 'macOS' }}
-        run: npm run build:app -- -- -- --publish never dmg --x64 --arm64
+        run: npm run build:app -- -- -- dmg --publish never --x64 --arm64
 
       - name: Build Electron app (Linux)
         if: ${{ runner.os == 'Linux' }}
-        run: npm run build:app -- -- -- --publish never AppImage deb rpm --x64 --arm64
+        run: npm run build:app -- -- -- AppImage deb rpm --publish never --x64 --arm64
 
       - name: Build Electron app (Windows)
         if: ${{ runner.os == 'Windows' }}
-        run: npm run build:app -- -- -- --publish never nsis --x64
+        run: npm run build:app -- -- -- nsis --publish never --x64
 
       - name: Upload binaries (macOS, Linux)
         if: ${{ runner.os != 'Windows' }}

--- a/.github/workflows/release-nightly.yml
+++ b/.github/workflows/release-nightly.yml
@@ -145,7 +145,10 @@ jobs:
 
       - name: Upload binaries (macOS, Linux)
         if: ${{ runner.os != 'Windows' }}
-        run: cd open-lens/dist && gh release upload nightly-${{ needs.make-draft-release.outputs.date }} $(yq -r '.files[].url' latest-*.yml) --repo dex4er/freelens-nightly-builds
+        run: |
+          cd open-lens/dist
+          rm -f *.blockmap
+          gh release upload nightly-${{ needs.make-draft-release.outputs.date }} Freelens-*.* --repo dex4er/freelens-nightly-builds
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
@@ -153,14 +156,9 @@ jobs:
         if: ${{ runner.os == 'Windows' }}
         shell: pwsh
         run: |
-          Install-Module -Name powershell-yaml -RequiredVersion 0.4.2 -Force
           Set-Location -Path "open-lens/dist"
-          $yamlFiles = Get-ChildItem -Filter 'latest-*.yml'
-          $files = foreach ($yamlFile in $yamlFiles) {
-            $yamlContent = Get-Content -Path $yamlFile.FullName | ConvertFrom-Yaml
-            $yamlContent.files.url
-          }
-          gh release upload nightly-${{ needs.make-draft-release.outputs.date }} $files --repo dex4er/freelens-nightly-builds
+          Remove-Item -Path *.blockmap -Force
+          gh release upload nightly-${{ needs.make-draft-release.outputs.date }} Freelens-*.* --repo dex4er/freelens-nightly-builds
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 

--- a/.github/workflows/release-nightly.yml
+++ b/.github/workflows/release-nightly.yml
@@ -28,9 +28,10 @@ jobs:
         run: echo "date=$(date +'%Y-%m-%d')" >> $GITHUB_ENV
 
       - name: Delete existing nightly release
-        run: gh release delete nightly-${{ env.date }} -y || true
-        env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        uses: liudonghua123/delete-release-action@v1
+        with:
+          release_name: nightly-${{ env.date }}
+          suppress_errors: true
 
       - name: Create nightly release
         uses: viperproject/create-nightly-release@v1

--- a/.github/workflows/release-nightly.yml
+++ b/.github/workflows/release-nightly.yml
@@ -34,15 +34,15 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
 
-      - name: Delete existing nightly release
+      - name: Delete existing nightly build
         if: github.ref_name == 'main'
         run: gh release delete nightly-${{ env.date }} --yes --cleanup-tag || true
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Create nightly release draft
+      - name: Create nightly build draft
         if: github.ref_name == 'main'
-        run: gh release create nightly-${{ env.date }} --draft --title "Nightly Release ${{ env.date }}"
+        run: gh release create nightly-${{ env.date }} --draft --title "Nightly build ${{ env.date }}"
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
@@ -194,7 +194,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
 
-      - name: Add notes to nightly release
+      - name: Add notes to nightly build
         if: github.ref_name == 'main'
         run: gh release edit nightly-${{ needs.make-draft-release.outputs.date }} --notes="Based on https://github.com/freelensapp/freelens/tree/${{ needs.build-app.outputs.sha }}"
         env:
@@ -217,7 +217,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
 
-      - name: Publish nightly release
+      - name: Publish nightly build
         if: github.ref_name == 'main'
         run: gh release edit nightly-${{ needs.make-draft-release.outputs.date }} --draft=false
         env:

--- a/.github/workflows/release-nightly.yml
+++ b/.github/workflows/release-nightly.yml
@@ -63,9 +63,13 @@ jobs:
       matrix:
         include:
           - os: ubuntu-latest
+            arch: arm64
+          - os: ubuntu-latest
             arch: x64
           - os: macos-latest
             arch: arm64
+          - os: macos-latest
+            arch: x86
           - os: windows-latest
             arch: x64
 
@@ -95,9 +99,9 @@ jobs:
         id: npm-cache
         with:
           path: ${{ env.npm_cache_dir }}
-          key: ${{ runner.os }}-node-${{ hashFiles('**/package-lock.json') }}
+          key: ${{ matrix.os }}-${{ matrix.arch }}-node-${{ hashFiles('**/package-lock.json') }}
           restore-keys: |
-            ${{ runner.os }}-node-
+            ${{ matrix.os }}-${{ matrix.arch }}-node-
 
       - name: Install dependencies (Linux)
         if: runner.os == 'Linux'
@@ -113,6 +117,15 @@ jobs:
 
       - name: Install required dependencies
         run: npm ci
+
+      - name: Rebuild for arch (macOS, Linux)
+        if: runner.os != 'Windows'
+        run: |
+          if [[ ${{ runner.os }} == Linux && ${{ matrix.arch }} == arm64 ]]; then
+            export CC=aarch64-linux-gnu-gcc
+            export CXX=aarch64-linux-gnu-g++
+          fi
+          npm run rebuild -- -- -a ${{ matrix.arch }}
 
       - name: Build
         run: npm run build

--- a/.github/workflows/release-nightly.yml
+++ b/.github/workflows/release-nightly.yml
@@ -1,0 +1,108 @@
+name: Release nightly
+
+on:
+  push:
+    branches:
+      - "**"
+  pull_request:
+    branches:
+      - main
+  schedule:
+    - cron: "0 2 * * *"
+  workflow_dispatch: {}
+
+permissions:
+  contents: read
+
+jobs:
+  make-release:
+    name: make release
+
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Get current date
+        id: date
+        run: echo "date=$(date +'%Y-%m-%d')" >> $GITHUB_ENV
+
+      - name: Create nightly release
+        uses: viperproject/create-nightly-release@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          tag_name: nightly-${{ env.date }}
+          release_name: Nightly Release ${{ env.date }}
+          keep_num: 0
+          keep_tags: false
+
+    outputs:
+      date: ${{ env.date }}
+
+  build-app:
+    name: build app
+
+    needs:
+      - make-release
+
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - os: ubuntu-latest
+            arch: x64
+          - os: macos-latest
+            arch: arm64
+          - os: windows-latest
+            arch: x64
+
+    runs-on: ${{ matrix.os }}
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          repository: dex4er/freelens
+
+      - name: Setup node
+        uses: actions/setup-node@v4
+        with:
+          node-version-file: .nvmrc
+
+      - name: Get npm cache directory (Bash)
+        if: ${{ runner.os != 'Windows' }}
+        run: echo "npm_cache_dir=$(npm config get cache)" >> ${GITHUB_ENV}
+
+      - name: Get npm cache directory (Pwsh)
+        if: ${{ runner.os == 'Windows' }}
+        shell: pwsh
+        run: echo "npm_cache_dir=$(npm config get cache)" >> ${env:GITHUB_ENV}
+
+      - uses: actions/cache@v4
+        id: npm-cache
+        with:
+          path: ${{ env.npm_cache_dir }}
+          key: ${{ runner.os }}-node-${{ hashFiles('**/package-lock.json') }}
+          restore-keys: |
+            ${{ runner.os }}-node-
+
+      - name: Install Python setuptools (macOS)
+        if: ${{ runner.os == 'macOS' }}
+        run: brew install python-setuptools
+
+      - name: Install minikube (Linux)
+        if: ${{ runner.os == 'Linux' }}
+        uses: medyagh/setup-minikube@master
+        with:
+          kubernetes-version: v1.30.1
+
+      - name: Install required dependencies
+        run: npm ci
+
+      - name: Build
+        run: npm run build
+
+      - name: Build Electron app
+        run: npm run build:app
+
+      - name: Upload binaries
+        run: cd open-lens/dist && gh release upload nightly-${{ needs.make-release.outputs.date }} $(yq -r '.files[].url' latest-*.yml)

--- a/.github/workflows/release-nightly.yml
+++ b/.github/workflows/release-nightly.yml
@@ -145,7 +145,7 @@ jobs:
         run: npm run build:app -- -- -- nsis --publish never --x64
 
       - name: Upload binaries (macOS, Linux)
-        if: runner.os != 'Windows'
+        if: runner.os != 'Windows' && github.ref_name == 'dex4er'
         run: |
           cd open-lens/dist
           rm -f *.blockmap
@@ -157,7 +157,7 @@ jobs:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Upload binaries (Windows)
-        if: runner.os == 'Windows'
+        if: runner.os == 'Windows' && github.ref_name == 'dex4er'
         shell: pwsh
         run: |
           Set-Location -Path "open-lens/dist"

--- a/.github/workflows/release-nightly.yml
+++ b/.github/workflows/release-nightly.yml
@@ -149,6 +149,9 @@ jobs:
         run: |
           cd open-lens/dist
           rm -f *.blockmap
+          for i in $(find . -name '*.dmg' ! -name '*-arm64.dmg'); do
+            mv $i ${i%.dmg}-amd64.dmg
+          done
           gh release upload nightly-${{ needs.make-draft-release.outputs.date }} Freelens-*.* --repo dex4er/freelens-nightly-builds
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/release-nightly.yml
+++ b/.github/workflows/release-nightly.yml
@@ -152,7 +152,7 @@ jobs:
           for i in $(find . -name '*.dmg' ! -name '*-arm64.dmg'); do
             mv $i ${i%.dmg}-amd64.dmg
           done
-          gh release upload nightly-${{ needs.make-draft-release.outputs.date }} Freelens-*.* --repo dex4er/freelens-nightly-builds
+          gh release upload nightly-${{ needs.make-draft-release.outputs.date }} Freelens*.* --repo dex4er/freelens-nightly-builds
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
@@ -162,7 +162,7 @@ jobs:
         run: |
           Set-Location -Path "open-lens/dist"
           Remove-Item -Path *.blockmap -Force
-          gh release upload nightly-${{ needs.make-draft-release.outputs.date }} Freelens-*.* --repo dex4er/freelens-nightly-builds
+          gh release upload nightly-${{ needs.make-draft-release.outputs.date }} Freelens*.* --repo dex4er/freelens-nightly-builds
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 

--- a/.github/workflows/release-nightly.yml
+++ b/.github/workflows/release-nightly.yml
@@ -110,3 +110,5 @@ jobs:
 
       - name: Upload binaries
         run: cd open-lens/dist && gh release upload nightly-${{ needs.make-release.outputs.date }} $(yq -r '.files[].url' latest-*.yml)
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/release-nightly.yml
+++ b/.github/workflows/release-nightly.yml
@@ -97,12 +97,6 @@ jobs:
         if: ${{ runner.os == 'macOS' }}
         run: brew install python-setuptools
 
-      - name: Install minikube (Linux)
-        if: ${{ runner.os == 'Linux' }}
-        uses: medyagh/setup-minikube@master
-        with:
-          kubernetes-version: v1.30.1
-
       - name: Install required dependencies
         run: npm ci
 
@@ -111,6 +105,8 @@ jobs:
 
       - name: Build Electron app
         run: npm run build:app
+        env:
+          BUILD_NUMBER: nightly-${{ needs.make-draft-release.outputs.date }}
 
       - name: Upload binaries (Bash)
         if: ${{ runner.os != 'Windows' }}

--- a/.github/workflows/release-nightly.yml
+++ b/.github/workflows/release-nightly.yml
@@ -136,6 +136,9 @@ jobs:
         if: runner.os == 'macOS'
         run: npm run build:app -- -- -- dmg --publish never --${{ matrix.arch }}
         env:
+          APPLEID: ${{ secrets.APPLEID }}
+          APPLEIDPASS: ${{ secrets.APPLEIDPASS }}
+          APPLETEAMID: ${{ secrets.APPLETEAMID }}
           CSC_LINK: ${{ secrets.CSC_LINK }}
           CSC_KEY_PASSWORD: ${{ secrets.CSC_KEY_PASSWORD }}
 

--- a/.github/workflows/release-nightly.yml
+++ b/.github/workflows/release-nightly.yml
@@ -11,6 +11,10 @@ on:
     - cron: "0 2 * * *"
   workflow_dispatch: {}
 
+concurrency:
+  group: ${{ github.workflow }}
+  cancel-in-progress: true
+
 permissions:
   contents: write
 

--- a/.github/workflows/release-nightly.yml
+++ b/.github/workflows/release-nightly.yml
@@ -9,7 +9,7 @@ on:
   workflow_dispatch: {}
 
 concurrency:
-  group: ${{ github.workflow }}
+  group: ${{ github.workflow }}-${{ github.ref_name }}
   cancel-in-progress: true
 
 permissions:
@@ -32,11 +32,13 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Delete existing nightly release
+        if: github.ref_name == 'dex4er'
         run: gh release delete nightly-${{ env.date }} --yes --cleanup-tag || true
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Create nightly release draft
+        if: github.ref_name == 'dexter'
         run: gh release create nightly-${{ env.date }} --draft --title "Nightly Release ${{ env.date }}"
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -79,11 +81,11 @@ jobs:
           node-version-file: .nvmrc
 
       - name: Get npm cache directory (macOS, Linux)
-        if: ${{ runner.os != 'Windows' }}
+        if: runner.os != 'Windows'
         run: echo "npm_cache_dir=$(npm config get cache)" >> ${GITHUB_ENV}
 
       - name: Get npm cache directory (Windows)
-        if: ${{ runner.os == 'Windows' }}
+        if: runner.os == 'Windows'
         shell: pwsh
         run: echo "npm_cache_dir=$(npm config get cache)" >> ${env:GITHUB_ENV}
 
@@ -96,19 +98,19 @@ jobs:
             ${{ runner.os }}-node-
 
       - name: Install cross-compiler (Linux)
-        if: ${{ runner.os == 'Linux' }}
+        if: runner.os == 'Linux'
         run: sudo apt-get install -y --no-install-recommends gcc-aarch64-linux-gnu g++-aarch64-linux-gnu
 
       - name: Install Python setuptools (macOS)
-        if: ${{ runner.os == 'macOS' }}
+        if: runner.os == 'macOS'
         run: brew install python-setuptools
 
       - name: Set version number and NPM rebuild (macOS, Linux)
-        if: ${{ runner.os != 'Windows' }}
+        if: runner.os != 'Windows'
         run: yq -i -pj -oj ".version += \"-nightly-${{ needs.make-draft-release.outputs.date }}\" | .build.npmRebuild = true" package.json
 
       - name: Set version number and NPM rebuild (Windows)
-        if: ${{ runner.os == 'Windows' }}
+        if: runner.os == 'Windows'
         shell: pwsh
         run: |
           $packageJsonPath = "open-lens\package.json"
@@ -125,22 +127,22 @@ jobs:
       - name: Build
         run: npm run build
         env:
-          DOWNLOAD_ALL_ARCHITECTURES: "${{ runner.os != 'Windows' }}"
+          DOWNLOAD_ALL_ARCHITECTURES: "runner.os != 'Windows'"
 
       - name: Build Electron app (macOS)
-        if: ${{ runner.os == 'macOS' }}
+        if: runner.os == 'macOS'
         run: npm run build:app -- -- -- dmg --publish never --x64 --arm64
 
       - name: Build Electron app (Linux)
-        if: ${{ runner.os == 'Linux' }}
+        if: runner.os == 'Linux'
         run: npm run build:app -- -- -- AppImage deb rpm --publish never --x64 --arm64
 
       - name: Build Electron app (Windows)
-        if: ${{ runner.os == 'Windows' }}
+        if: runner.os == 'Windows'
         run: npm run build:app -- -- -- nsis --publish never --x64
 
       - name: Upload binaries (macOS, Linux)
-        if: ${{ runner.os != 'Windows' }}
+        if: runner.os != 'Windows'
         run: |
           cd open-lens/dist
           rm -f *.blockmap
@@ -149,7 +151,7 @@ jobs:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Upload binaries (Windows)
-        if: ${{ runner.os == 'Windows' }}
+        if: runner.os == 'Windows'
         shell: pwsh
         run: |
           Set-Location -Path "open-lens/dist"
@@ -175,6 +177,7 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Publish nightly release
+        if: github.ref_name == 'dex4er'
         run: gh release edit nightly-${{ needs.make-draft-release.outputs.date }} --draft=false
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/release-nightly.yml
+++ b/.github/workflows/release-nightly.yml
@@ -105,7 +105,7 @@ jobs:
 
       - name: Set version number and tweak build parameters
         shell: bash
-        run: jq ".version += \"-nightly-${{ needs.make-draft-release.outputs.date }}\" | .build.npmRebuild = true" package.json > package.json.new && mv -f package.json.new package.json
+        run: cd open-lens && jq ".version += \"-nightly-${{ needs.make-draft-release.outputs.date }}\" | .build.npmRebuild = true" package.json > package.json.new && mv -f package.json.new package.json
 
       - name: Install required dependencies
         run: npm ci

--- a/.github/workflows/release-nightly.yml
+++ b/.github/workflows/release-nightly.yml
@@ -167,8 +167,10 @@ jobs:
     outputs:
       sha: ${{ steps.current_revision.outputs.sha }}
 
-  publish-release:
-    name: publish release
+  add-notes-to-release:
+    name: add notes to release
+
+    if: ${{ always() }}
 
     needs:
       - make-draft-release
@@ -183,8 +185,31 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
 
+      - name: Add notes to nightly release
+        if: github.ref_name == 'dex4er'
+        run: gh release edit nightly-${{ needs.make-draft-release.outputs.date }} --notes="Based on https://github.com/dex4er/freelens/tree/${{ needs.build-app.outputs.sha }}"
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+  publish-release:
+    name: publish release
+
+    needs:
+      - make-draft-release
+      - build-app
+      - add-notes-to-release
+
+    permissions:
+      contents: write
+
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
       - name: Publish nightly release
         if: github.ref_name == 'dex4er'
-        run: gh release edit nightly-${{ needs.make-draft-release.outputs.date }} --draft=false --notes="Based on https://github.com/dex4er/freelens/tree/${{ needs.build-app.outputs.sha }}}"
+        run: gh release edit nightly-${{ needs.make-draft-release.outputs.date }} --draft=false
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/release-nightly.yml
+++ b/.github/workflows/release-nightly.yml
@@ -4,6 +4,9 @@ on:
   push:
     branches:
       - "**"
+  pull_request:
+    branches:
+      - main
   schedule:
     - cron: "0 2 * * *"
   workflow_dispatch: {}

--- a/.github/workflows/release-nightly.yml
+++ b/.github/workflows/release-nightly.yml
@@ -29,6 +29,8 @@ jobs:
 
       - name: Delete existing nightly release
         uses: liudonghua123/delete-release-action@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
           release_name: nightly-${{ env.date }}
           suppress_errors: true

--- a/.github/workflows/release-nightly.yml
+++ b/.github/workflows/release-nightly.yml
@@ -134,15 +134,15 @@ jobs:
 
       - name: Build Electron app (macOS)
         if: runner.os == 'macOS'
-        run: npm run build:app -- -- -- dmg --publish never --x64 --arm64
+        run: npm run build:app -- -- -- dmg --publish never --${{ matrix.arch }}
 
       - name: Build Electron app (Linux)
         if: runner.os == 'Linux'
-        run: npm run build:app -- -- -- AppImage deb rpm --publish never --x64 --arm64
+        run: npm run build:app -- -- -- AppImage deb rpm --publish never --${{ matrix.arch }}
 
       - name: Build Electron app (Windows)
         if: runner.os == 'Windows'
-        run: npm run build:app -- -- -- nsis --publish never --x64
+        run: npm run build:app -- -- -- nsis --publish never --${{ matrix.arch }}
 
       - name: Tweak binaries before upload
         shell: bash

--- a/.github/workflows/release-nightly.yml
+++ b/.github/workflows/release-nightly.yml
@@ -103,11 +103,11 @@ jobs:
         if: ${{ runner.os == 'macOS' }}
         run: brew install python-setuptools
 
-      - name: Set version number
+      - name: Set version number and NPM rebuild (macOS, Linux)
         if: ${{ runner.os != 'Windows' }}
-        run: yq -i -pj -oj ".version += \"-nightly-${{ needs.make-draft-release.outputs.date }}\"" package.json
+        run: yq -i -pj -oj ".version += \"-nightly-${{ needs.make-draft-release.outputs.date }}\" | .build.npmRebuild = true" package.json
 
-      - name: Set version number (Windows)
+      - name: Set version number and NPM rebuild (Windows)
         if: ${{ runner.os == 'Windows' }}
         shell: pwsh
         run: |
@@ -115,6 +115,7 @@ jobs:
           $packageJsonContent = Get-Content -Path $packageJsonPath -Raw
           $packageJson = $packageJsonContent | ConvertFrom-Json
           $packageJson.version = $packageJson.version + "-nightly-${{ needs.make-draft-release.outputs.date }}"
+          $packageJson.build.npmRebuild = True
           $updatedPackageJsonContent = $packageJson | ConvertTo-Json -Depth 100
           $updatedPackageJsonContent | Set-Content -Path $packageJsonPath -Force
 
@@ -128,15 +129,15 @@ jobs:
 
       - name: Build Electron app (macOS)
         if: ${{ runner.os == 'macOS' }}
-        run: npm run build:app -- -- -- --x64 --arm64
+        run: npm run build:app -- -- -- --publish never --x64 --arm64
 
       - name: Build Electron app (Linux)
         if: ${{ runner.os == 'Linux' }}
-        run: npm run build:app -- -- -- --x64 --arm64
+        run: npm run build:app -- -- -- --publish never --x64 --arm64
 
       - name: Build Electron app (Windows)
         if: ${{ runner.os == 'Windows' }}
-        run: npm run build:app -- -- -- --x64
+        run: npm run build:app -- -- -- --publish never --x64
 
       - name: Upload binaries (macOS, Linux)
         if: ${{ runner.os != 'Windows' }}

--- a/.github/workflows/release-nightly.yml
+++ b/.github/workflows/release-nightly.yml
@@ -135,6 +135,9 @@ jobs:
       - name: Build Electron app (macOS)
         if: runner.os == 'macOS'
         run: npm run build:app -- -- -- dmg --publish never --${{ matrix.arch }}
+        env:
+          CSC_LINK: ${{ secrets.CSC_LINK }}
+          CSC_KEY_PASSWORD: ${{ secrets.CSC_KEY_PASSWORD }}
 
       - name: Build Electron app (Linux)
         if: runner.os == 'Linux'
@@ -143,6 +146,9 @@ jobs:
       - name: Build Electron app (Windows)
         if: runner.os == 'Windows'
         run: npm run build:app -- -- -- nsis --publish never --${{ matrix.arch }}
+        env:
+          CSC_LINK: ${{ secrets.WIN_CSC_LINK }}
+          CSC_KEY_PASSWORD: ${{ secrets.WIN_CSC_KEY_PASSWORD }}
 
       - name: Tweak binaries before upload
         shell: bash

--- a/README.md
+++ b/README.md
@@ -1,1 +1,7 @@
 # freelens-nightly-builds
+
+This is a project with nightly builds.
+
+You can find the packages built from the main branch here:
+
+<https://github.com/freelensapp/freelens-nightly-builds/releases>


### PR DESCRIPTION
It relies on https://github.com/freelensapp/freelens/pull/11 to be merged and https://github.com/freelensapp/freelens/issues/13 to be fixed.

* Does not clean old builds (ie. olders than 10th)
* No signing key for MacOS as I don't have any yet = broken app, even if it might be started from the command line

As the main project should be able to build with a minimum number of targets by default to not rely on special setup (cross-compilers, specific OS distribution with additional tools for packaging: deb, rpm, snap, flatpak),
this repo should build them all.

This build workflow uses a rather pure `gh` command than some actions from the market, as I found that most of them are already outdated or don't work as expected.

The last build: https://github.com/dex4er/freelens-nightly-builds/releases/tag/nightly-2024-08-15

Please squash it.
