### PR TITLE
Remove Flatpak from the release

### DIFF
--- a/.github/workflows/release-nightly.yml
+++ b/.github/workflows/release-nightly.yml
@@ -121,29 +121,6 @@ jobs:
             sudo apt-get install -y --no-install-recommends \
               gcc-aarch64-linux-gnu g++-aarch64-linux-gnu
 
-      - name: Install Flatpak (Linux x64)
-        if: runner.os == 'Linux' && matrix.arch == 'x64'
-        uses: nick-fields/retry@v3
-        with:
-          timeout_minutes: 20
-          max_attempts: 3
-          retry_on: any
-          command: |
-            sudo apt-get install -y --no-install-recommends \
-              flatpak flatpak-builder
-            sudo flatpak remote-add --if-not-exists --system flathub https://flathub.org/repo/flathub.flatpakrepo
-            sudo flatpak install -y --system org.freedesktop.Platform/x86_64/20.08
-            sudo flatpak install -y --system org.electronjs.Electron2.BaseApp/x86_64/20.08
-            sudo flatpak install -y --system org.freedesktop.Sdk/x86_64/20.08
-
-      - name: Install LXD for Snapcraft (Linux x64)
-        if: runner.os == 'Linux' && matrix.arch == 'x64'
-        uses: canonical/setup-lxd@main
-
-      - name: Install Snapcraft (Linux x64)
-        if: runner.os == 'Linux' && matrix.arch == 'x64'
-        run: sudo snap install snapcraft --classic
-
       - name: Install dependencies (macOS)
         if: runner.os == 'macOS'
         uses: nick-fields/retry@v3
@@ -200,18 +177,8 @@ jobs:
           CSC_LINK: ${{ secrets.CSC_LINK }}
           CSC_KEY_PASSWORD: ${{ secrets.CSC_KEY_PASSWORD }}
 
-      - name: Build Electron app (Linux x64)
-        if: runner.os == 'Linux' && matrix.arch == 'x64'
-        run: |
-          npm run build:app -- -- -- \
-            AppImage deb flatpak rpm \
-            --publish never \
-            --${{ matrix.arch }}
-        env:
-          DEBUG: "@malept/flatpak-bundler"
-
-      - name: Build Electron app (Linux arm64)
-        if: runner.os == 'Linux' && matrix.arch == 'arm64'
+      - name: Build Electron app (Linux)
+        if: runner.os == 'Linux'
         run: |
           npm run build:app -- -- -- \
             AppImage deb rpm \
@@ -232,24 +199,6 @@ jobs:
         env:
           CSC_LINK: ${{ secrets.WIN_CSC_LINK }}
           CSC_KEY_PASSWORD: ${{ secrets.WIN_CSC_KEY_PASSWORD }}
-
-      - name: Build Snap (Linux x64)
-        if: runner.os == 'Linux' && matrix.arch == 'x64'
-        run: |
-          case ${{ matrix.arch }} in
-            arm64) arch=arm64;;
-            x64) arch=amd64;;
-          esac
-          cd freelens/dist
-          cp -a ../build/{gui,icon.png,snapcraft.yaml} .
-          yq -i ".version += \"-nightly-${{ needs.make-draft-release.outputs.date }}\"" snapcraft.yaml
-          yq -i '.grade = "devel"' snapcraft.yaml
-          yq -i '.architectures[0].run-on = "'$arch'"' snapcraft.yaml
-          yq -i '.parts.freelens.source = "'$(echo *.deb)'"' snapcraft.yaml
-          snapcraft --use-lxd
-          file=$(echo *.snap)
-          snap info $file
-          mv -f "$file" "${file/freelens/Freelens}"
 
       - name: Tweak binaries
         shell: bash

--- a/.github/workflows/release-nightly.yml
+++ b/.github/workflows/release-nightly.yml
@@ -271,10 +271,10 @@ jobs:
             if (/\.(dmg|exe|msi|pkg)$/ && !/-(amd64|arm64)\./) {
               s/\.(dmg|exe|msi|pkg)$/-$arch.$1/;
             }
-            s/\.(aarch64|arm64)/-arm64/;
-            s/\.(amd64|x86_64)/-amd64/;
+            s/[.-](aarch64|arm64)/-arm64/;
+            s/[.-](amd64|x86-64)/-amd64/;
             s/-(amd64|arm64).(dmg|pkg)$/-macos-$1.$2/;
-            s/-(amd64|arm64).(AppImage|deb|flatpak|rpm)$/-linux-$1.$2/;
+            s/-(amd64|arm64).(AppImage|deb|flatpak|rpm|snap)$/-linux-$1.$2/;
             s/-(amd64|arm64).(exe|msi|)$/-windows-$1.$2/;
             my $dst = $_;
             if ($src ne $dst) {

--- a/.github/workflows/release-nightly.yml
+++ b/.github/workflows/release-nightly.yml
@@ -234,7 +234,7 @@ jobs:
           CSC_KEY_PASSWORD: ${{ secrets.WIN_CSC_KEY_PASSWORD }}
 
       - name: Build Snap (Linux x64)
-        if: runner.os == 'Linux'
+        if: runner.os == 'Linux' && matrix.arch == 'x64'
         run: |
           case ${{ matrix.arch }} in
             arm64) arch=arm64;;

--- a/.github/workflows/release-nightly.yml
+++ b/.github/workflows/release-nightly.yml
@@ -132,9 +132,9 @@ jobs:
             sudo apt-get install -y --no-install-recommends \
               flatpak flatpak-builder
             sudo flatpak remote-add --if-not-exists --system flathub https://flathub.org/repo/flathub.flatpakrepo
-            sudo flatpak install -y --system org.freedesktop.Platform/x64_64/20.08
-            sudo flatpak install -y --system org.electronjs.Electron2.BaseApp/x64_64/20.08
-            sudo flatpak install -y --system org.freedesktop.Sdk/x64_64/20.08
+            sudo flatpak install -y --system org.freedesktop.Platform/x86_64/20.08
+            sudo flatpak install -y --system org.electronjs.Electron2.BaseApp/x86_64/20.08
+            sudo flatpak install -y --system org.freedesktop.Sdk/x86_64/20.08
 
       - name: Install LXD for Snapcraft (Linux x64)
         if: runner.os == 'Linux' && matrix.arch == 'x64'
@@ -272,7 +272,7 @@ jobs:
               s/\.(dmg|exe|msi|pkg)$/-$arch.$1/;
             }
             s/\.(aarch64|arm64)/-arm64/;
-            s/\.(amd64|x64_64)/-amd64/;
+            s/\.(amd64|x86_64)/-amd64/;
             s/-(amd64|arm64).(dmg|pkg)$/-macos-$1.$2/;
             s/-(amd64|arm64).(AppImage|deb|flatpak|rpm)$/-linux-$1.$2/;
             s/-(amd64|arm64).(exe|msi|)$/-windows-$1.$2/;

--- a/.github/workflows/release-nightly.yml
+++ b/.github/workflows/release-nightly.yml
@@ -136,6 +136,14 @@ jobs:
             sudo flatpak install -y --system org.electronjs.Electron2.BaseApp/x86_64/20.08
             sudo flatpak install -y --system org.freedesktop.Sdk/x86_64/20.08
 
+      - name: Install LXD for Snapcraft (Linux)
+        if: runner.os == 'Linux'
+        uses: canonical/setup-lxd@main
+
+      - name: Install Snapcraft (Linux)
+        if: runner.os == 'Linux'
+        run: sudo snap install snapcraft --classic
+
       - name: Install dependencies (macOS)
         if: runner.os == 'macOS'
         uses: nick-fields/retry@v3
@@ -241,7 +249,7 @@ jobs:
           while (<Freelens*>) {
             my $src = $_;
             s/ Setup /-/;
-            s/ /-/g;
+            s/[ _]/-/g;
             if (/\.(dmg|exe|msi|pkg)$/ && !/-(amd64|arm64)\./) {
               s/\.(dmg|exe|msi|pkg)$/-$arch.$1/;
             }

--- a/.github/workflows/release-nightly.yml
+++ b/.github/workflows/release-nightly.yml
@@ -233,6 +233,24 @@ jobs:
           CSC_LINK: ${{ secrets.WIN_CSC_LINK }}
           CSC_KEY_PASSWORD: ${{ secrets.WIN_CSC_KEY_PASSWORD }}
 
+      - name: Build Snap (Linux)
+        if: runner.os == 'Linux'
+        run: |
+          case ${{ matrix.arch }} in
+            arm64) arch=arm64;;
+            x86) arch=amd64;;
+          esac
+          cd freelens/dist
+          cp -a ../build/{gui,icon.png,snapcraft.yaml} .
+          yq -i ".version += \"-nightly-${{ needs.make-draft-release.outputs.date }}\"" snapcraft.yaml
+          yq -i '.grade = "devel"' snapcraft.yaml
+          yq -i '.architectures[0].run-on = "'$arch'"' snapcraft.yaml
+          yq -i '.parts.freelens.source = "'$(echo *.deb)'"' snapcraft.yaml
+          snapcraft --use-lxd
+          file=$(echo *.snap)
+          snap info $file
+          mv -f "$file" "${file/freelens/Freelens}"
+
       - name: Tweak binaries
         shell: bash
         run: |

--- a/.github/workflows/release-nightly.yml
+++ b/.github/workflows/release-nightly.yml
@@ -132,16 +132,16 @@ jobs:
             sudo apt-get install -y --no-install-recommends \
               flatpak flatpak-builder
             sudo flatpak remote-add --if-not-exists --system flathub https://flathub.org/repo/flathub.flatpakrepo
-            sudo flatpak install -y --system org.freedesktop.Platform/x86_64/20.08
-            sudo flatpak install -y --system org.electronjs.Electron2.BaseApp/x86_64/20.08
-            sudo flatpak install -y --system org.freedesktop.Sdk/x86_64/20.08
+            sudo flatpak install -y --system org.freedesktop.Platform/x64_64/20.08
+            sudo flatpak install -y --system org.electronjs.Electron2.BaseApp/x64_64/20.08
+            sudo flatpak install -y --system org.freedesktop.Sdk/x64_64/20.08
 
-      - name: Install LXD for Snapcraft (Linux)
-        if: runner.os == 'Linux'
+      - name: Install LXD for Snapcraft (Linux x64)
+        if: runner.os == 'Linux' && matrix.arch == 'x64'
         uses: canonical/setup-lxd@main
 
-      - name: Install Snapcraft (Linux)
-        if: runner.os == 'Linux'
+      - name: Install Snapcraft (Linux x64)
+        if: runner.os == 'Linux' && matrix.arch == 'x64'
         run: sudo snap install snapcraft --classic
 
       - name: Install dependencies (macOS)
@@ -218,7 +218,7 @@ jobs:
             --publish never \
             --${{ matrix.arch }}
 
-      - name: Build Electron app (Windows x86)
+      - name: Build Electron app (Windows x64)
         if: runner.os == 'Windows' && matrix.arch == 'x64'
         shell: bash
         run: |
@@ -238,7 +238,7 @@ jobs:
         run: |
           case ${{ matrix.arch }} in
             arm64) arch=arm64;;
-            x86) arch=amd64;;
+            x64) arch=amd64;;
           esac
           cd freelens/dist
           cp -a ../build/{gui,icon.png,snapcraft.yaml} .
@@ -272,7 +272,7 @@ jobs:
               s/\.(dmg|exe|msi|pkg)$/-$arch.$1/;
             }
             s/\.(aarch64|arm64)/-arm64/;
-            s/\.(amd64|x86_64)/-amd64/;
+            s/\.(amd64|x64_64)/-amd64/;
             s/-(amd64|arm64).(dmg|pkg)$/-macos-$1.$2/;
             s/-(amd64|arm64).(AppImage|deb|flatpak|rpm)$/-linux-$1.$2/;
             s/-(amd64|arm64).(exe|msi|)$/-windows-$1.$2/;

--- a/.github/workflows/release-nightly.yml
+++ b/.github/workflows/release-nightly.yml
@@ -233,7 +233,7 @@ jobs:
           CSC_LINK: ${{ secrets.WIN_CSC_LINK }}
           CSC_KEY_PASSWORD: ${{ secrets.WIN_CSC_KEY_PASSWORD }}
 
-      - name: Build Snap (Linux)
+      - name: Build Snap (Linux x64)
         if: runner.os == 'Linux'
         run: |
           case ${{ matrix.arch }} in


### PR DESCRIPTION
Flatpak is preferred to be built in a separate workflow.

The workflow used here was:

```yaml
      - name: Install Flatpak (Linux x64)
        if: runner.os == 'Linux' && matrix.arch == 'x64'
        uses: nick-fields/retry@v3
        with:
          timeout_minutes: 20
          max_attempts: 3
          retry_on: any
          command: |
            sudo apt-get install -y --no-install-recommends \
              flatpak flatpak-builder
            sudo flatpak remote-add --if-not-exists --system flathub https://flathub.org/repo/flathub.flatpakrepo
            sudo flatpak install -y --system org.freedesktop.Platform/x86_64/20.08
            sudo flatpak install -y --system org.electronjs.Electron2.BaseApp/x86_64/20.08
            sudo flatpak install -y --system org.freedesktop.Sdk/x86_64/20.08

      - name: Build Electron app (Linux x64)
        if: runner.os == 'Linux' && matrix.arch == 'x64'
        run: |
          npm run build:app -- -- -- \
            flatpak \
            --publish never \
            --${{ matrix.arch }}
        env:
          DEBUG: "@malept/flatpak-bundler"
```

however if separate manifest will be used then most likely it'll be based on the existing DEB package, similarly to Snaps.