### PR TITLE
CI: conditional environment

### DIFF
--- a/.github/workflows/release-nightly.yml
+++ b/.github/workflows/release-nightly.yml
@@ -76,7 +76,7 @@ jobs:
             arch: x64
 
     runs-on: ${{ matrix.os }}
-    environment: test-signing
+    environment: ${{ github.ref_name == 'main' && 'test-signing' || null }}
 
     steps:
       - name: Checkout


### PR DESCRIPTION
It should use environments for notarizing only for main branch.