### PR TITLE
DOWNLOAD_ALL_ARCHITECTURE=true on macOS x64 and Linux arm64

### DIFF
--- a/.github/workflows/release-nightly.yml
+++ b/.github/workflows/release-nightly.yml
@@ -153,7 +153,14 @@ jobs:
         if: runner.os == 'macOS' && matrix.arch == 'x64'
         run: npm run rebuild -- -- -a x64
 
-      - name: Build
+      - name: Build NPM packages (macOS x64, Linux arm64)
+        if: runner.os == 'macOS' && matrix.arch == 'x64' || runner.os == 'Linux' && matrix.arch == 'arm64'
+        run: npm run build
+        env:
+          DOWNLOAD_ALL_ARCHITECTURES: "true"
+
+      - name: Build NPM packages (macOS arm64, Linux x64, Windows)
+        if: runner.os == 'macOS' && matrix.arch == 'arm64' || runner.os == 'Linux' && matrix.arch == 'x64' || runner.os == 'Windows'
         run: npm run build
 
       - name: Build Electron app (macOS)


### PR DESCRIPTION
Follow up of https://github.com/freelensapp/freelens/pull/61

It should fix DEB and RPM packages for arm64.