### PR TITLE
Drop electron-rebuild and python-setuptools for vite migration

### DIFF
--- a/.github/workflows/release-nightly.yaml
+++ b/.github/workflows/release-nightly.yaml
@@ -126,7 +126,7 @@ jobs:
 
       - name: Install dependencies (macOS)
         if: runner.os == 'macOS'
-        run: brew install bash coreutils python-setuptools
+        run: brew install bash coreutils
 
       - name: Add coreutils to PATH (macOS)
         if: runner.os == 'macOS'
@@ -249,12 +249,6 @@ jobs:
         run: pnpm --color=always --stream build
         env:
           TURBO_CONCURRENCY: "2"
-
-      - name: Rebuild native packages for Electron
-        run: pnpm --color=always electron-rebuild -a ${{ matrix.arch }}
-        env:
-          npm_config_arch: ${{ matrix.arch }}
-          npm_config_target_arch: ${{ matrix.arch }}
 
       - name: Build extra resources
         id: build-resources


### PR DESCRIPTION
## Summary

The upstream freelens webpack->vite migration removes native module rebuilding from the app. This aligns the nightly release workflow with that change.

Reference: freelensapp/freelens commit [`39d366e2`](https://github.com/freelensapp/freelens/commit/39d366e2) — "Drop electron-rebuild and node-gyp in favor of node-pty prebuilds" (#2128). With `electron-vite`, the app no longer compiles native modules — `node-pty` ships prebuilt binaries that electron-builder selects per architecture, so `node-gyp`, `@electron/rebuild` and the `electron-rebuild` script were removed from the app and from upstream's `release.yaml` / `integration-tests.yaml`.

## Changes to `release-nightly.yaml`

- **Remove the "Rebuild native packages for Electron" step.** The `electron-rebuild` binary no longer exists in the app, so keeping the step would fail the build once vite lands on `main`. Cross-arch builds are covered by node-pty prebuilds instead of the `npm_config_arch` rebuild.
- **Drop `python-setuptools`** from the macOS `brew install`; it existed only so node-gyp could compile native modules.

## Not needed here

- No "Deploy production node_modules" step: that exists only in upstream `integration-tests.yaml` (which builds `dir` and runs the app directly). Upstream `release.yaml` does not have it, and this workflow mirrors `release.yaml`.
- This repo never adopted the `ELECTRON_HEADERS_CACHE` / "Install Electron headers" steps, so there is nothing to remove there.

## Validation

- `trunk` pre-commit hook: no issues.
- YAML parses cleanly (`yq`).

[View job run] | Model: `claude-opus-4-8`