### PR TITLE
Port pnpm v11 and Electron cache changes from upstream release workflow

### DIFF
--- a/.github/workflows/release-nightly.yaml
+++ b/.github/workflows/release-nightly.yaml
@@ -186,7 +186,7 @@ jobs:
 
       - name: Disable pre post scripts for pnpm
         shell: bash
-        run: pnpm config set enablePrePostScripts false
+        run: pnpm config set enablePrePostScripts false --location project
 
       - name: Get Electron version
         shell: bash

--- a/.github/workflows/release-nightly.yaml
+++ b/.github/workflows/release-nightly.yaml
@@ -295,6 +295,7 @@ jobs:
           CSC_KEY_PASSWORD: ${{ secrets.CSC_KEY_PASSWORD }}
           CSC_INSTALLER_LINK: ${{ secrets.CSC_INSTALLER_LINK }}
           CSC_INSTALLER_KEY_PASSWORD: ${{ secrets.CSC_INSTALLER_KEY_PASSWORD }}
+          DEBUG: electron-builder,electron-builder:*
 
       - name: Notarize PKG (macOS)
         id: notarize-pkg
@@ -365,6 +366,8 @@ jobs:
           pnpm --color=always build:app \
             AppImage deb rpm \
             --${{ matrix.arch }}
+        env:
+          DEBUG: electron-builder,electron-builder:*
 
       # Windows is built in two phases so the native binaries that electron
       # unpacks next to the app (node-pty's pty.node / conpty.node /
@@ -381,6 +384,8 @@ jobs:
           pnpm --color=always build:app \
             dir \
             --${{ matrix.arch }}
+        env:
+          DEBUG: electron-builder,electron-builder:*
 
       - name: Verify app.asar
         shell: bash
@@ -473,6 +478,7 @@ jobs:
             --prepackaged "$GITHUB_WORKSPACE/freelens/dist/$unpacked" \
             --${{ matrix.arch }}
         env:
+          DEBUG: electron-builder,electron-builder:*
           TURBO_FORCE: "true"
 
       - name: Azure Trusted Signing (Windows)

--- a/.github/workflows/release-nightly.yaml
+++ b/.github/workflows/release-nightly.yaml
@@ -234,6 +234,19 @@ jobs:
         shell: bash
         run: pnpm install --color=always --prefer-offline --frozen-lockfile
 
+      # Electron downloads its runtime binary lazily on the first require(),
+      # not during pnpm install (pnpm runs no dependency build scripts by
+      # default, and node-pty now ships prebuilds so nothing rebuilds Electron
+      # either). Fetch and extract it once here so electron-builder reuses it
+      # from the GitHub-cached ELECTRON_CACHE instead of downloading it at pack
+      # time. electron/install.js reads its cache dir from electron_config_cache.
+      - name: Install Electron binary
+        shell: bash
+        working-directory: freelens
+        env:
+          electron_config_cache: ${{ env.ELECTRON_CACHE }}
+        run: node "$(node -p "require.resolve('electron/install.js')")"
+
       - name: Build packages
         if: runner.os != 'Windows'
         run: pnpm --color=always --stream build

--- a/.github/workflows/release-nightly.yaml
+++ b/.github/workflows/release-nightly.yaml
@@ -104,9 +104,9 @@ jobs:
       group: ${{ github.workflow }}-${{ github.ref_name }}-${{ matrix.os }}-${{ matrix.arch }}
 
     env:
-      ELECTRON_CACHE: ${{ github.workspace }}/.cache/electron
-      ELECTRON_BUILDER_CACHE: ${{ github.workspace }}/.cache/electron-builder
       DO_NOT_TRACK: "1"
+      ELECTRON_BUILDER_CACHE: ${{ github.workspace }}/.cache/electron-builder
+      ELECTRON_CACHE: ${{ github.workspace }}/.cache/electron
 
     steps:
       - name: Checkout freelensapp/freelens
@@ -180,9 +180,9 @@ jobs:
         uses: actions/cache@v6
         with:
           path: ${{ env.pnpm_cache_dir }}
-          key: ${{ matrix.os }}-${{ matrix.arch }}-node-${{ hashFiles('pnpm-lock.yaml') }}
+          key: ${{ matrix.runs-on }}-${{ matrix.arch }}-node-${{ hashFiles('pnpm-lock.yaml') }}
           restore-keys: |
-            ${{ matrix.os }}-${{ matrix.arch }}-node-
+            ${{ matrix.runs-on }}-${{ matrix.arch }}-node-
 
       - name: Disable pre post scripts for pnpm
         shell: bash
@@ -202,17 +202,17 @@ jobs:
         uses: actions/cache@v6
         with:
           path: ${{ env.ELECTRON_CACHE }}
-          key: ${{ matrix.os }}-${{ matrix.arch }}-electron-${{ env.electron_version }}
+          key: ${{ matrix.runs-on }}-${{ matrix.arch }}-electron-${{ env.electron_version }}
           restore-keys: |
-            ${{ matrix.os }}-${{ matrix.arch }}-electron-
+            ${{ matrix.runs-on }}-${{ matrix.arch }}-electron-
 
       - name: Use Electron Builder cache
         uses: actions/cache@v6
         with:
           path: ${{ env.ELECTRON_BUILDER_CACHE }}
-          key: ${{ matrix.os }}-${{ matrix.arch }}-electron-builder-${{ env.electron_builder_version }}
+          key: ${{ matrix.runs-on }}-${{ matrix.arch }}-electron-builder-${{ env.electron_builder_version }}
           restore-keys: |
-            ${{ matrix.os }}-${{ matrix.arch }}-electron-builder-
+            ${{ matrix.runs-on }}-${{ matrix.arch }}-electron-builder-
 
       - name: Tweak package for nightly build
         shell: bash

--- a/.github/workflows/release-nightly.yaml
+++ b/.github/workflows/release-nightly.yaml
@@ -143,7 +143,7 @@ jobs:
           YQ_VERSION: v4.53.3 # datasource=github-releases depName=mikefarah/yq
         run: |
           set -eo pipefail
-          # winget is not available on every Windows runner image (in
+          # winget/choco is not available on every Windows runner image (in
           # particular the windows-11-arm image used for the arm64 build), so
           # download the yq binary directly from the upstream GitHub release.
           # Pick the asset that matches the runner architecture. Expose the
@@ -492,7 +492,7 @@ jobs:
           trusted-signing-account-name: ${{ vars.AZURE_CODE_SIGNING_NAME }}
           certificate-profile-name: ${{ vars.AZURE_CERT_PROFILE_NAME }}
           files-folder: ${{ github.workspace }}\freelens\dist
-          files-folder-filter: exe,msi,portable
+          files-folder-filter: exe,msi
 
       - name: Tweak binaries
         shell: bash


### PR DESCRIPTION
## Why

The nightly release [failed](https://github.com/freelensapp/freelens-nightly-builds/actions/runs/29674645151) at the **Disable pre post scripts for pnpm** step. After upstream `freelensapp/freelens` upgraded pnpm to v11 (freelensapp/freelens#2047) and completed the webpack to vite migration, its release workflow gained changes that were never ported here. This ports the functional fixes plus the remaining cosmetic differences so the two workflows stay consistent.

## Functional fixes

1. **Add `--location project` to `pnpm config set`** — in pnpm v11 `pnpm config set enablePrePostScripts false` without an explicit location no longer writes the project config and fails the step. Matches upstream `release.yaml`.

2. **Download the Electron binary explicitly into the cache before build** — with the vite migration Electron is no longer rebuilt during install, and Electron now fetches its runtime binary lazily on the first `require()` rather than at `pnpm install` time. A new **Install Electron binary** step runs `electron/install.js` with `electron_config_cache` pointed at `ELECTRON_CACHE`, so the binary is downloaded once and reused from the GitHub-cached directory by electron-builder. Mirrors the upstream caching approach (freelensapp/freelens#2227).

## Consistency with upstream (cosmetic)

3. **Key CI caches by `matrix.runs-on`** (instead of `matrix.os`) and order the build-app `env` vars the same as upstream. Each `(os, arch)` maps to a single `runs-on`, so cache scoping is unchanged.
4. **Enable `DEBUG=electron-builder,electron-builder:*`** on all `build:app` steps, as upstream does, for matching packaging diagnostics.
5. **Drop the dead `portable` token** from the Azure Trusted Signing `files-folder-filter` (the portable target emits a `.exe`, already covered by `exe`) and align the yq install comment.

Note: the `| tee -a $GITHUB_ENV` pattern in the Get Electron version/builder steps is intentionally kept (not switched to `>>`) because `tee` echoes the assigned value into the log, which helps troubleshooting.

## Out of scope

Structural differences that are intentional for the nightly workflow (schedule/PR triggers, double checkout, nightly versioning + APT keyring injection, `main`/non-PR guards on upload and signing, the extra `Verify app.asar` hardening step, no npm publish job) are left untouched.

## Validation

- YAML validated with `yq` (all edited steps parse and are present).
- Functional verification happens on this PR's workflow run / the next nightly, since the failing step only executes in CI.