### PR TITLE
Publish Grype SBOM vulnerability report to code scanning

### DIFF
--- a/.github/workflows/release-nightly.yaml
+++ b/.github/workflows/release-nightly.yaml
@@ -702,3 +702,73 @@ jobs:
         env:
           tag: ${{ needs.make-draft-release.outputs.tag }}
           GH_TOKEN: ${{ secrets.GH_TOKEN }}
+
+  security-scan:
+    name: security scan
+
+    # Runs only for the real nightly (main, non-PR): the SBOMs are attached to
+    # the draft release by the build-app job, which itself only uploads on
+    # main. Independent of publish-release/APT so it can be re-run on its own.
+    if: github.ref_name == 'main' && github.event_name != 'pull_request'
+
+    needs:
+      - make-draft-release
+      - build-app
+
+    runs-on: ubuntu-24.04-arm
+
+    permissions:
+      actions: read
+      contents: read
+      security-events: write
+
+    env:
+      # Renovate keeps this version up to date via the customManagers hint in
+      # .renovaterc.json5 (value must be whitespace-delimited for the regex to
+      # capture it, hence the env var rather than a bash assignment).
+      GRYPE_VERSION: v0.116.0 # datasource=github-releases depName=anchore/grype
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v7
+
+      - name: Download SBOMs from release
+        run: |
+          mkdir -p sboms
+          gh release download "$tag" \
+            --pattern '*-sbom.spdx.json' \
+            --dir sboms \
+            --repo freelensapp/freelens-nightly-builds
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          tag: ${{ needs.make-draft-release.outputs.tag }}
+
+      - name: Install Grype
+        run: |
+          curl -sSfL https://raw.githubusercontent.com/anchore/grype/main/install.sh \
+            | sh -s -- -b "$RUNNER_TEMP/bin" "$GRYPE_VERSION"
+          echo "$RUNNER_TEMP/bin" >> "$GITHUB_PATH"
+
+      - name: Scan SBOMs with Grype
+        run: |
+          set -eo pipefail
+          mkdir -p sarifs
+          shopt -s nullglob
+          found=0
+          for sbom in sboms/*-sbom.spdx.json; do
+            name=$(basename "$sbom" .spdx.json)
+            echo "::group::grype ${sbom}"
+            grype "sbom:${sbom}" -o sarif > "sarifs/${name}.sarif"
+            echo "::endgroup::"
+            found=$((found + 1))
+          done
+          if [[ "$found" -eq 0 ]]; then
+            echo "No SBOM files found to scan under sboms/" >&2
+            exit 1
+          fi
+
+      - name: Upload Grype SARIF to code scanning
+        uses: github/codeql-action/upload-sarif@v3
+        with:
+          sarif_file: sarifs
+          category: grype


### PR DESCRIPTION
## What

Adds an independent **`security-scan`** job to the nightly release workflow that surfaces dependency vulnerabilities in the GitHub **Security -> Code scanning** tab.

Flow:
1. Downloads the per-arch SBOMs (`*-sbom.spdx.json`) that `build-app` already attaches to the nightly draft release.
2. Scans each SBOM with **Grype** (pinned via `GRYPE_VERSION`, Renovate-managed) and emits one SARIF per SBOM.
3. Uploads the whole SARIF directory to code scanning with `github/codeql-action/upload-sarif@v3` under a single `grype` category.

## Design notes

- **Independent job** — `needs: [make-draft-release, build-app]` only, and nothing depends on it. So it can be **re-run on its own** (retry) without redoing the build, and a scan failure never blocks publish/APT.
- **Gated to `main` and non-PR** — the SBOMs only exist as release assets on the real nightly (build-app uploads are similarly gated), so the job would have nothing to download on a PR.
- **Permissions** — job-scoped: `security-events: write` (SARIF upload) + `contents: read` (release download) + `actions: read`.
- **Single upload, one category** — the six SARIF files are uploaded as one submission (directory upload), so per-arch results don't overwrite each other the way separate same-category uploads would.

## Known tradeoff

Scanning all six SBOMs means a CVE in a shared JS dependency shows up once per arch (locations differ by SBOM filename), so alerts can be duplicated ~6x. If that proves noisy, the loop can be narrowed to a single representative SBOM (e.g. `linux-amd64`) since the JS dependency tree is essentially identical across platforms; only native prebuilds differ. Left scanning all for completeness — easy to trim later.

## Validation

- YAML validated with `yq` (job and steps parse; `security-scan` present with the five steps).
- Real verification happens on the next nightly / a manual `workflow_dispatch` on `main`, since the job needs release assets that only exist there.