### PR TITLE
Fix Electron cache path and retry packaging in the nightly release workflow

### DIFF
--- a/.github/workflows/release-nightly.yaml
+++ b/.github/workflows/release-nightly.yaml
@@ -113,7 +113,6 @@ jobs:
     env:
       DO_NOT_TRACK: "1"
       ELECTRON_BUILDER_CACHE: ${{ github.workspace }}/.cache/electron-builder
-      ELECTRON_CACHE: ${{ github.workspace }}/.cache/electron
 
     steps:
       - name: Checkout freelensapp/freelens
@@ -205,16 +204,39 @@ jobs:
         run: echo "electron_builder_version=$(yq -py -oy .importers.freelens.devDependencies.electron-builder.version pnpm-lock.yaml
           | sed 's/(.*)//')" | tee -a $GITHUB_ENV
 
-      - name: Use Electron cache
-        uses: actions/cache@v6
+      # electron-builder's Electron zip downloader doesn't accept a cache
+      # directory override and always writes into the OS-default Electron cache
+      # dir (see freelensapp/freelens#2305). Point both the "Install Electron
+      # binary" step and this cache at that real directory so the two share one
+      # @electron/get cache and electron-builder reuses the pre-downloaded
+      # binary instead of fetching it again.
+      - name: Get Electron cache directory
+        shell: bash
+        run: |
+          case "${{ matrix.os }}" in
+            linux) dir="$HOME/.cache/electron" ;;
+            macos) dir="$HOME/Library/Caches/electron" ;;
+            windows) dir="$LOCALAPPDATA/electron/Cache" ;;
+          esac
+          echo "electron_cache_dir=$dir" | tee -a $GITHUB_ENV
+
+      # Split restore/save (save runs under if: always() after the build steps
+      # below) so a packaging failure that happens after the binaries finish
+      # downloading still saves the cache. The combined actions/cache action
+      # only saves in a post-job step that a failed job skips
+      # (freelensapp/freelens#2303).
+      - name: Restore Electron cache
+        id: electron-cache-restore
+        uses: actions/cache/restore@v6
         with:
-          path: ${{ env.ELECTRON_CACHE }}
+          path: ${{ env.electron_cache_dir }}
           key: ${{ matrix.runs-on }}-${{ matrix.arch }}-electron-${{ env.electron_version }}
           restore-keys: |
             ${{ matrix.runs-on }}-${{ matrix.arch }}-electron-
 
-      - name: Use Electron Builder cache
-        uses: actions/cache@v6
+      - name: Restore Electron Builder cache
+        id: electron-builder-cache-restore
+        uses: actions/cache/restore@v6
         with:
           path: ${{ env.ELECTRON_BUILDER_CACHE }}
           key: ${{ matrix.runs-on }}-${{ matrix.arch }}-electron-builder-${{ env.electron_builder_version }}
@@ -244,14 +266,16 @@ jobs:
       # Electron downloads its runtime binary lazily on the first require(),
       # not during pnpm install (pnpm runs no dependency build scripts by
       # default, and node-pty now ships prebuilds so nothing rebuilds Electron
-      # either). Fetch and extract it once here so electron-builder reuses it
-      # from the GitHub-cached ELECTRON_CACHE instead of downloading it at pack
-      # time. electron/install.js reads its cache dir from electron_config_cache.
+      # either). Fetch and extract it once here, into the same OS-default
+      # @electron/get cache directory electron-builder uses at pack time, so
+      # electron-builder reuses it instead of re-downloading it (see
+      # freelensapp/freelens#2305). electron/install.js reads its cache dir
+      # from electron_config_cache.
       - name: Install Electron binary
         shell: bash
         working-directory: freelens
         env:
-          electron_config_cache: ${{ env.ELECTRON_CACHE }}
+          electron_config_cache: ${{ env.electron_cache_dir }}
         run: node "$(node -p "require.resolve('electron/install.js')")"
 
       - name: Build packages
@@ -286,7 +310,32 @@ jobs:
         run: pnpm --color=always build:resources
 
       - name: Build Electron app (macOS)
+        id: build-macos
         if: runner.os == 'macOS'
+        run: |
+          for var in APPLEID APPLEIDPASS APPLETEAMID CSC_LINK CSC_KEY_PASSWORD CSC_INSTALLER_LINK CSC_INSTALLER_KEY_PASSWORD; do
+            test -n "${!var}" || unset $var
+          done
+          pnpm --color=always build:app \
+            dmg pkg \
+            --${{ matrix.arch }}
+        env:
+          APPLEID: ${{ secrets.APPLEID }}
+          APPLEIDPASS: ${{ secrets.APPLEIDPASS }}
+          APPLETEAMID: ${{ secrets.APPLETEAMID }}
+          CSC_LINK: ${{ secrets.CSC_LINK }}
+          CSC_KEY_PASSWORD: ${{ secrets.CSC_KEY_PASSWORD }}
+          CSC_INSTALLER_LINK: ${{ secrets.CSC_INSTALLER_LINK }}
+          CSC_INSTALLER_KEY_PASSWORD: ${{ secrets.CSC_INSTALLER_KEY_PASSWORD }}
+          DEBUG: electron-builder,electron-builder:*
+        continue-on-error: true
+
+      # Retry once to absorb a transient Electron/toolset download failure
+      # during packaging (see freelensapp/freelens#2303). Rebuilding and
+      # re-signing from scratch is idempotent; notarization happens in the
+      # separate steps below.
+      - name: Build Electron app (macOS) (retry)
+        if: runner.os == 'macOS' && steps.build-macos.outcome == 'failure'
         run: |
           for var in APPLEID APPLEIDPASS APPLETEAMID CSC_LINK CSC_KEY_PASSWORD CSC_INSTALLER_LINK CSC_INSTALLER_KEY_PASSWORD; do
             test -n "${!var}" || unset $var
@@ -368,7 +417,20 @@ jobs:
           APPLETEAMID: ${{ secrets.APPLETEAMID }}
 
       - name: Build Electron app (Linux)
+        id: build-linux
         if: runner.os == 'Linux'
+        run: |
+          pnpm --color=always build:app \
+            AppImage deb rpm \
+            --${{ matrix.arch }}
+        env:
+          DEBUG: electron-builder,electron-builder:*
+        continue-on-error: true
+
+      # Retry once to absorb a transient Electron/toolset download failure
+      # during packaging (see freelensapp/freelens#2303).
+      - name: Build Electron app (Linux) (retry)
+        if: runner.os == 'Linux' && steps.build-linux.outcome == 'failure'
         run: |
           pnpm --color=always build:app \
             AppImage deb rpm \
@@ -385,7 +447,21 @@ jobs:
       #
       # Phase 1: produce the unpacked app directory only (no installers).
       - name: Build Electron app directory (Windows)
+        id: build-windows-dir
         if: runner.os == 'Windows'
+        shell: bash
+        run: |
+          pnpm --color=always build:app \
+            dir \
+            --${{ matrix.arch }}
+        env:
+          DEBUG: electron-builder,electron-builder:*
+        continue-on-error: true
+
+      # Retry once to absorb a transient Electron/toolset download failure
+      # during packaging (see freelensapp/freelens#2303).
+      - name: Build Electron app directory (Windows) (retry)
+        if: runner.os == 'Windows' && steps.build-windows-dir.outcome == 'failure'
         shell: bash
         run: |
           pnpm --color=always build:app \
@@ -473,6 +549,7 @@ jobs:
       # rebuilding it (--prepackaged), so the signed binaries are preserved.
       # TURBO_FORCE avoids turbo restoring a cached, unsigned dist directory.
       - name: Build Electron app installers (Windows)
+        id: build-windows-installers
         if: runner.os == 'Windows'
         shell: bash
         run: |
@@ -487,6 +564,47 @@ jobs:
         env:
           DEBUG: electron-builder,electron-builder:*
           TURBO_FORCE: "true"
+        continue-on-error: true
+
+      # Retry once to absorb a transient toolset download failure (NSIS,
+      # winCodeSign, ...) during installer packaging (see
+      # freelensapp/freelens#2303). Runs against the already-signed unpacked
+      # dir, so it only re-runs the installer assembly.
+      - name: Build Electron app installers (Windows) (retry)
+        if: runner.os == 'Windows' && steps.build-windows-installers.outcome == 'failure'
+        shell: bash
+        run: |
+          case "${{ matrix.arch }}" in
+            arm64) unpacked="win-arm64-unpacked" ;;
+            *) unpacked="win-unpacked" ;;
+          esac
+          pnpm --color=always build:app \
+            msi nsis portable \
+            --prepackaged "$GITHUB_WORKSPACE/freelens/dist/$unpacked" \
+            --${{ matrix.arch }}
+        env:
+          DEBUG: electron-builder,electron-builder:*
+          TURBO_FORCE: "true"
+
+      # Save the Electron and electron-builder caches unconditionally (the
+      # counterpart to the split restore steps above): whatever the build steps
+      # downloaded is cached even when a later packaging/signing step fails, so
+      # a re-run does not re-download the binaries (freelensapp/freelens#2303).
+      # Skip on an exact cache hit (the primary key already exists, so the save
+      # would only warn "Unable to reserve cache ...").
+      - name: Save Electron cache
+        if: always() && steps.electron-cache-restore.outputs.cache-hit != 'true'
+        uses: actions/cache/save@v6
+        with:
+          path: ${{ env.electron_cache_dir }}
+          key: ${{ steps.electron-cache-restore.outputs.cache-primary-key }}
+
+      - name: Save Electron Builder cache
+        if: always() && steps.electron-builder-cache-restore.outputs.cache-hit != 'true'
+        uses: actions/cache/save@v6
+        with:
+          path: ${{ env.ELECTRON_BUILDER_CACHE }}
+          key: ${{ steps.electron-builder-cache-restore.outputs.cache-primary-key }}
 
       - name: Azure Trusted Signing (Windows)
         if: runner.os == 'Windows' && github.ref_name == 'main' && github.event_name != 'pull_request'


### PR DESCRIPTION
Ports the cache-mechanism fixes from [freelensapp/freelens#2305](https://github.com/freelensapp/freelens/pull/2305) to `release-nightly.yaml`, which shares the same Electron caching and packaging structure as the main repo's `release.yaml`.

## Problem

- The `Use Electron cache` step cached `$ELECTRON_CACHE` (`${{ github.workspace }}/.cache/electron`), but electron-builder's Electron zip downloader reads **no** cache-dir env var and always writes to the OS-default `@electron/get` directory (`~/.cache/electron`, `~/Library/Caches/electron`, `%LOCALAPPDATA%\electron\Cache`). So the cached directory was the wrong one and electron-builder re-downloaded Electron at pack time on every run — despite the "Install Electron binary" step, which wrote to a *different* directory (`electron_config_cache=$ELECTRON_CACHE`).
- The combined `actions/cache` action only saves in a post-job step, which is skipped once a later step in the job fails, so a packaging failure after the binaries downloaded left the cache empty (see freelensapp/freelens#2303).

## Fix

- **Cache the real OS-default directory**, computed per `matrix.os`. Point both the `Install Electron binary` step's `electron_config_cache` and the cache at that directory, so `install.js` pre-warms exactly the `@electron/get` cache electron-builder consumes — the two now share one cache and electron-builder reuses the pre-downloaded binary.
- **Split restore/save** for both the Electron and Electron-Builder caches (`actions/cache/restore` + `actions/cache/save` with `if: always()`, skipped on an exact cache hit to avoid the benign "Unable to reserve cache" warning). The Electron-Builder cache stays because the nightly builds real installers, which download electron-builder toolsets.
- **Retry each packaging step once** (macOS/Linux/Windows-dir/Windows-installers) with the existing `continue-on-error` + conditional-retry pattern, to absorb a single transient Electron/toolset download failure.

## Test plan

- [x] `yq e '.'` — YAML parses
- [x] `trunk check .github/workflows/release-nightly.yaml` — no issues
- [ ] Verified in the main repo (#2305): after the fix the Electron cache is restored (115–141 MB) and reused (the "download" resolves in ~0.2 s from cache), so the miss→re-download loop is broken. A nightly run will exercise the same path here.

Companion to freelensapp/freelens#2305.

| Model: `claude-sonnet-5`